### PR TITLE
Fix replication using undeprecated methods

### DIFF
--- a/mobile/ios/Classes/TDDatabaseProxy.m
+++ b/mobile/ios/Classes/TDDatabaseProxy.m
@@ -197,7 +197,7 @@ extern NSString* const kCBLDatabaseChangeNotification;
     RELEASE_TO_NIL(lastError)
     
     NSURL * url = [NSURL URLWithString:urlstr];
-    CBLReplication * replication = [self.database pushToURL:url];
+    CBLReplication * replication = [self.database replicationToURL:url];
     return [[TDReplicationProxy alloc] initWithExecutionContext:[self executionContext] CBLReplication:replication];
 }
 
@@ -208,7 +208,7 @@ extern NSString* const kCBLDatabaseChangeNotification;
     RELEASE_TO_NIL(lastError)
     
     NSURL * url = [NSURL URLWithString:urlstr];
-    CBLReplication * replication = [self.database pullFromURL:url];
+    CBLReplication * replication = [self.database replicationFromURL:url];
     return [[TDReplicationProxy alloc] initWithExecutionContext:[self executionContext] CBLReplication:replication];
 }
 
@@ -221,7 +221,7 @@ extern NSString* const kCBLDatabaseChangeNotification;
     RELEASE_TO_NIL(lastError)
     
     NSURL * url = [NSURL URLWithString:urlstr];
-    NSArray * repls = [self.database replicateWithURL:url exclusively:[exclusive boolValue]];
+    NSArray * repls = [self.database replicationsWithURL:url exclusively:[exclusive boolValue]];
     
     NSMutableArray * result = [NSMutableArray arrayWithCapacity:[repls count]];
     for (CBLReplication * repl in repls) {


### PR DESCRIPTION
New methods don't call start automatically. This is important when filters, etc are setup after a replication is created in a multithreaded environment. This fixes an issue where ti_touchdb would sync once at startup but never again.

I had to point the couchbase-lite-ios submodule to the upstream version since I wasn't able to update the pegli repo yet. I'm not committing that change. I'm not sure how to deal with something like that with submodules. Git subtree would help, but then you're embedding the whole thing... Is there a reason not to point the submodule at the couch repo?
