### PR TITLE
Need to lookup view by name when falling back to default (not the view[0] object).

### DIFF
--- a/mobile/noarch/alloy/sync/titouchdb.js
+++ b/mobile/noarch/alloy/sync/titouchdb.js
@@ -78,7 +78,7 @@ function Sync(method, model, options) {
         var collection = model; // just to clear things up 
         
         // collection
-        var view = opts.view || collection.config.adapter.views[0];
+        var view = opts.view || collection.config.adapter.views[0]["name"];
         
         // add default view options from model
         opts = _.defaults(opts, collection.config.adapter.view_options);


### PR DESCRIPTION
view looks to be the string name in this instance, not the {} object defining the view...
